### PR TITLE
Initialization fixes

### DIFF
--- a/pkg/rdt/config.go
+++ b/pkg/rdt/config.go
@@ -260,8 +260,8 @@ func (a l3PctRangeAllocation) Overlay(baseMask Bitmask) (Bitmask, error) {
 	if bits.OnesCount64(uint64(baseMask)) != int(baseMaskNumBits) {
 		return 0, rdtError("invalid basemask %#x: more than one block of bits set", baseMask)
 	}
-	if uint64(bits.OnesCount64(uint64(baseMask))) < rdt.info.l3MinCbmBits() {
-		return 0, rdtError("invalid basemask %#x: fewer than %d bits set", baseMask, rdt.info.l3MinCbmBits())
+	if uint64(bits.OnesCount64(uint64(baseMask))) < info.l3MinCbmBits() {
+		return 0, rdtError("invalid basemask %#x: fewer than %d bits set", baseMask, info.l3MinCbmBits())
 	}
 
 	low, high := a.lowPct, a.highPct
@@ -280,8 +280,8 @@ func (a l3PctRangeAllocation) Overlay(baseMask Bitmask) (Bitmask, error) {
 
 	// Make sure the number of bits set satisfies the minimum requirement
 	numBits := msb - lsb + 1
-	if numBits < rdt.info.l3MinCbmBits() {
-		gap := rdt.info.l3MinCbmBits() - numBits
+	if numBits < info.l3MinCbmBits() {
+		gap := info.l3MinCbmBits() - numBits
 
 		// First, widen the mask from the "lsb end"
 		if gap <= lsb {
@@ -331,7 +331,7 @@ func (s mbSchema) ToStr(base map[uint64]uint64) string {
 	for _, id := range ids {
 		baseAllocation := base[id]
 		value := uint64(0)
-		if rdt.info.mb.mbpsEnabled {
+		if info.mb.mbpsEnabled {
 			value = math.MaxUint32
 			if s != nil {
 				value = s[id]
@@ -347,8 +347,8 @@ func (s mbSchema) ToStr(base map[uint64]uint64) string {
 			}
 			value = allocation * baseAllocation / 100
 			// Guarantee minimum bw so that writing out the schemata does not fail
-			if value < rdt.info.mb.minBandwidth {
-				value = rdt.info.mb.minBandwidth
+			if value < info.mb.minBandwidth {
+				value = info.mb.minBandwidth
 			}
 		}
 
@@ -424,7 +424,7 @@ func (raw Config) resolve() (config, error) {
 func (raw Config) resolvePartitions() (partitionSet, error) {
 	// Initialize empty partition configuration
 	conf := make(partitionSet, len(raw.Partitions))
-	numCacheIds := len(rdt.info.cacheIds)
+	numCacheIds := len(info.cacheIds)
 	for name := range raw.Partitions {
 		conf[name] = partitionConfig{L3: make(l3Schema, numCacheIds),
 			MB: make(mbSchema, numCacheIds)}
@@ -447,8 +447,8 @@ func (raw Config) resolvePartitions() (partitionSet, error) {
 
 // resolveL3Partitions tries to resolve requested L3 allocations between partitions
 func (raw Config) resolveL3Partitions(conf partitionSet) error {
-	allocationsPerCacheID := make(map[uint64][]l3PartitionAllocation, len(rdt.info.cacheIds))
-	for _, id := range rdt.info.cacheIds {
+	allocationsPerCacheID := make(map[uint64][]l3PartitionAllocation, len(info.cacheIds))
+	for _, id := range info.cacheIds {
 		allocationsPerCacheID[id] = make([]l3PartitionAllocation, 0, len(raw.Partitions))
 	}
 	// Helper structure for printing out human-readable info in the end
@@ -482,7 +482,7 @@ func (raw Config) resolveL3Partitions(conf partitionSet) error {
 	}
 
 	// Next, try to resolve partition allocations, separately for each cache-id
-	fullBitmaskNumBits := uint64(rdt.info.l3CbmMask().lsbZero())
+	fullBitmaskNumBits := uint64(info.l3CbmMask().lsbZero())
 	for id, partitions := range allocationsPerCacheID {
 		err := conf.resolveCacheID(id, partitions)
 		if err != nil {
@@ -586,8 +586,8 @@ func (s partitionSet) resolveCacheIDRelative(id uint64, partitions []l3Partition
 	})
 
 	bitID := uint64(0)
-	minCbmBits := rdt.info.l3MinCbmBits()
-	fullBitmaskNumBits := uint64(rdt.info.l3CbmMask().lsbZero())
+	minCbmBits := info.l3MinCbmBits()
+	fullBitmaskNumBits := uint64(info.l3CbmMask().lsbZero())
 	for i, partition := range partitions {
 		bitsAvailable := fullBitmaskNumBits - bitID
 		percentageAvailable := bitsAvailable * 100 / fullBitmaskNumBits
@@ -655,8 +655,8 @@ func (raw Config) resolveMBPartitions(conf partitionSet) error {
 		for id, allocation := range allocations {
 			conf[name].MB[id] = allocation
 			// Check that we don't go under the minimum allowed bandwidth setting
-			if !rdt.info.mb.mbpsEnabled && allocation < rdt.info.mb.minBandwidth {
-				conf[name].MB[id] = rdt.info.mb.minBandwidth
+			if !info.mb.mbpsEnabled && allocation < info.mb.minBandwidth {
+				conf[name].MB[id] = info.mb.minBandwidth
 			}
 		}
 	}
@@ -753,8 +753,8 @@ func (raw rawAllocations) rawParse(defaultVal interface{}, initEmpty bool) (map[
 		return nil, fmt.Errorf("'all' is missing")
 	}
 
-	allocations := make(map[uint64]interface{}, len(rdt.info.cacheIds))
-	for _, i := range rdt.info.cacheIds {
+	allocations := make(map[uint64]interface{}, len(info.cacheIds))
+	for _, i := range info.cacheIds {
 		allocations[i] = defaultVal
 	}
 
@@ -881,8 +881,8 @@ func parseCacheAllocation(data string) (cacheAllocation, error) {
 	if numOnes != 64-bits.LeadingZeros64(value)-bits.TrailingZeros64(value) {
 		return nil, fmt.Errorf("invalid cache bitmask %q: more than one continuous block of ones", data)
 	}
-	if uint64(numOnes) < rdt.info.l3MinCbmBits() {
-		return nil, fmt.Errorf("invalid cache bitmask %q: number of bits less than %d", data, rdt.info.l3MinCbmBits())
+	if uint64(numOnes) < info.l3MinCbmBits() {
+		return nil, fmt.Errorf("invalid cache bitmask %q: number of bits less than %d", data, info.l3MinCbmBits())
 	}
 
 	return l3AbsoluteAllocation(value), nil
@@ -896,7 +896,7 @@ func parseMBAllocation(raw []interface{}) (uint64, error) {
 			return 0, fmt.Errorf("not a string value %q", v)
 		}
 		if strings.HasSuffix(strVal, mbSuffixPct) {
-			if !rdt.info.mb.mbpsEnabled {
+			if !info.mb.mbpsEnabled {
 				value, err := strconv.ParseUint(strings.TrimSuffix(strVal, mbSuffixPct), 10, 7)
 				if err != nil {
 					return 0, err
@@ -904,7 +904,7 @@ func parseMBAllocation(raw []interface{}) (uint64, error) {
 				return value, nil
 			}
 		} else if strings.HasSuffix(strVal, mbSuffixMbps) {
-			if rdt.info.mb.mbpsEnabled {
+			if info.mb.mbpsEnabled {
 				value, err := strconv.ParseUint(strings.TrimSuffix(strVal, mbSuffixMbps), 10, 32)
 				if err != nil {
 					return 0, err
@@ -917,7 +917,7 @@ func parseMBAllocation(raw []interface{}) (uint64, error) {
 	}
 
 	// No value for the active mode was specified
-	if rdt.info.mb.mbpsEnabled {
+	if info.mb.mbpsEnabled {
 		return 0, fmt.Errorf("missing 'MBps' value from mbSchema; required because 'mba_MBps' is enabled in the system")
 	}
 	return 0, fmt.Errorf("missing '%%' value from mbSchema; required because percentage-based MBA allocation is enabled in the system")

--- a/pkg/rdt/info.go
+++ b/pkg/rdt/info.go
@@ -27,8 +27,8 @@ import (
 	"strings"
 )
 
-// Info contains information about the RDT support in the system
-type info struct {
+// resctrlInfo contains information about the RDT support in the system
+type resctrlInfo struct {
 	resctrlPath      string
 	resctrlMountOpts map[string]struct{}
 	numClosids       uint64
@@ -61,7 +61,7 @@ type mbInfo struct {
 var mountInfoPath string = "/proc/mounts"
 
 // l3Info is a helper method for a "unified API" for getting L3 information
-func (i info) l3Info() l3Info {
+func (i *resctrlInfo) l3Info() l3Info {
 	switch {
 	case i.l3code.Supported():
 		return i.l3code
@@ -71,7 +71,7 @@ func (i info) l3Info() l3Info {
 	return i.l3
 }
 
-func (i info) l3CbmMask() Bitmask {
+func (i *resctrlInfo) l3CbmMask() Bitmask {
 	mask := i.l3Info().cbmMask
 	if mask != 0 {
 		return mask
@@ -79,13 +79,13 @@ func (i info) l3CbmMask() Bitmask {
 	return Bitmask(^uint64(0))
 }
 
-func (i info) l3MinCbmBits() uint64 {
+func (i *resctrlInfo) l3MinCbmBits() uint64 {
 	return i.l3Info().minCbmBits
 }
 
-func getRdtInfo() (info, error) {
+func getRdtInfo() (*resctrlInfo, error) {
 	var err error
-	info := info{}
+	info := &resctrlInfo{}
 
 	info.resctrlPath, info.resctrlMountOpts, err = getResctrlMountInfo()
 	if err != nil {

--- a/pkg/rdt/rdt.go
+++ b/pkg/rdt/rdt.go
@@ -136,6 +136,9 @@ type resctrlGroup struct {
 // may be called even before Initialize().
 func SetLogger(l Logger) {
 	log = l
+	if rdt != nil {
+		rdt.setLogger(l)
+	}
 }
 
 // Initialize discovers RDT support and initializes the  rdtControl singleton interface
@@ -224,6 +227,10 @@ func (c *control) getMonFeatures() map[MonResource][]string {
 	}
 
 	return ret
+}
+
+func (c *control) setLogger(l Logger) {
+	c.Logger = l
 }
 
 func (c *control) setConfig(newConfig *Config) error {

--- a/pkg/rdt/rdt.go
+++ b/pkg/rdt/rdt.go
@@ -50,9 +50,7 @@ var log Logger = NewLoggerWrapper(stdlog.New(os.Stderr, "[ rdt ] ", 0))
 
 var info *resctrlInfo
 
-var rdt *control = &control{
-	Logger: log,
-}
+var rdt *control
 
 // CtrlGroup defines the interface of one goresctrl managed RDT class
 type CtrlGroup interface {
@@ -166,27 +164,42 @@ func Initialize(resctrlGroupPrefix string, conf *Config) error {
 // SetConfig parses new configuration and reconfigures the resctrl filesystem
 // accordingly
 func SetConfig(c *Config) error {
-	return rdt.setConfig(c)
+	if rdt != nil {
+		return rdt.setConfig(c)
+	}
+	return rdtError("rdt not initialized")
 }
 
 // GetClass returns one RDT class
 func GetClass(name string) (CtrlGroup, bool) {
-	return rdt.getClass(name)
+	if rdt != nil {
+		return rdt.getClass(name)
+	}
+	return nil, false
 }
 
 // GetClasses returns all available RDT classes
 func GetClasses() []CtrlGroup {
-	return rdt.getClasses()
+	if rdt != nil {
+		return rdt.getClasses()
+	}
+	return []CtrlGroup{}
 }
 
 // MonSupported returns true if RDT monitoring features are available
 func MonSupported() bool {
-	return rdt.monSupported()
+	if rdt != nil {
+		return rdt.monSupported()
+	}
+	return false
 }
 
 // GetMonFeatures returns the available monitoring stats of each available monitoring technology
 func GetMonFeatures() map[MonResource][]string {
-	return rdt.getMonFeatures()
+	if rdt != nil {
+		return rdt.getMonFeatures()
+	}
+	return map[MonResource][]string{}
 }
 
 func (c *control) getClass(name string) (CtrlGroup, bool) {

--- a/pkg/rdt/rdt.go
+++ b/pkg/rdt/rdt.go
@@ -139,13 +139,11 @@ func SetLogger(l Logger) {
 }
 
 // Initialize discovers RDT support and initializes the  rdtControl singleton interface
-// NOTE: should only be called once in order to avoid adding multiple notifiers
-// TODO: support make multiple initializations, allowing e.g. "hot-plug" when
-// 		 resctrl filesystem is mounted
 func Initialize(resctrlGroupPrefix string, conf *Config) error {
 	var err error
 
-	rdt = &control{Logger: log, resctrlGroupPrefix: resctrlGroupPrefix}
+	info = nil
+	rdt = nil
 
 	// Get info from the resctrl filesystem
 	info, err = getRdtInfo()
@@ -153,10 +151,14 @@ func Initialize(resctrlGroupPrefix string, conf *Config) error {
 		return err
 	}
 
+	r := &control{Logger: log, resctrlGroupPrefix: resctrlGroupPrefix}
+
 	// Configure resctrl
-	if err = rdt.setConfig(conf); err != nil {
+	if err = r.setConfig(conf); err != nil {
 		return rdtError("configuration failed: %v", err)
 	}
+
+	rdt = r
 
 	return nil
 }

--- a/pkg/rdt/rdt.go
+++ b/pkg/rdt/rdt.go
@@ -43,11 +43,12 @@ type control struct {
 	resctrlGroupPrefix string
 	conf               config
 	rawConf            Config
-	info               info
 	classes            map[string]*ctrlGroup
 }
 
 var log Logger = NewLoggerWrapper(stdlog.New(os.Stderr, "[ rdt ] ", 0))
+
+var info *resctrlInfo
 
 var rdt *control = &control{
 	Logger: log,
@@ -149,7 +150,7 @@ func Initialize(resctrlGroupPrefix string, conf *Config) error {
 	rdt = &control{Logger: log, resctrlGroupPrefix: resctrlGroupPrefix}
 
 	// Get info from the resctrl filesystem
-	rdt.info, err = getRdtInfo()
+	info, err = getRdtInfo()
 	if err != nil {
 		return err
 	}
@@ -205,13 +206,13 @@ func (c *control) getClasses() []CtrlGroup {
 }
 
 func (c *control) monSupported() bool {
-	return c.info.l3mon.Supported()
+	return info.l3mon.Supported()
 }
 
 func (c *control) getMonFeatures() map[MonResource][]string {
 	ret := make(map[MonResource][]string)
-	if c.info.l3mon.Supported() {
-		ret[MonResourceL3] = append([]string{}, c.info.l3mon.monFeatures...)
+	if info.l3mon.Supported() {
+		ret[MonResourceL3] = append([]string{}, info.l3mon.monFeatures...)
 	}
 
 	return ret
@@ -289,7 +290,7 @@ func (c *control) configureResctrl(conf config) error {
 }
 
 func (c *control) classesFromResctrlFs() ([]ctrlGroup, error) {
-	r, err := resctrlGroupsFromFs(c.resctrlGroupPrefix, c.info.resctrlPath)
+	r, err := resctrlGroupsFromFs(c.resctrlGroupPrefix, info.resctrlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -301,11 +302,11 @@ func (c *control) classesFromResctrlFs() ([]ctrlGroup, error) {
 }
 
 func (c *control) readRdtFile(rdtPath string) ([]byte, error) {
-	return ioutil.ReadFile(filepath.Join(c.info.resctrlPath, rdtPath))
+	return ioutil.ReadFile(filepath.Join(info.resctrlPath, rdtPath))
 }
 
 func (c *control) writeRdtFile(rdtPath string, data []byte) error {
-	if err := ioutil.WriteFile(filepath.Join(c.info.resctrlPath, rdtPath), data, 0644); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(info.resctrlPath, rdtPath), data, 0644); err != nil {
 		return c.cmdError(err)
 	}
 	return nil
@@ -403,13 +404,13 @@ func (c *ctrlGroup) configure(name string, class classConfig,
 
 	// Handle L3 cache allocation
 	switch {
-	case rdt.info.l3.Supported():
+	case info.l3.Supported():
 		schema, err := class.L3Schema.ToStr(l3SchemaTypeUnified, partition.L3)
 		if err != nil {
 			return err
 		}
 		schemata += schema
-	case rdt.info.l3data.Supported() || rdt.info.l3code.Supported():
+	case info.l3data.Supported() || info.l3code.Supported():
 		schema, err := class.L3Schema.ToStr(l3SchemaTypeCode, partition.L3)
 		if err != nil {
 			return err
@@ -429,7 +430,7 @@ func (c *ctrlGroup) configure(name string, class classConfig,
 
 	// Handle memory bandwidth allocation
 	switch {
-	case rdt.info.mb.Supported():
+	case info.mb.Supported():
 		schemata += class.MBSchema.ToStr(partition.MB)
 	default:
 		if class.MBSchema != nil && !options.MB.Optional {
@@ -501,7 +502,7 @@ func (r *resctrlGroup) AddPids(pids ...string) error {
 func (r *resctrlGroup) GetMonData() MonData {
 	m := MonData{}
 
-	if rdt.info.l3mon.Supported() {
+	if info.l3mon.Supported() {
 		l3, err := r.getMonL3Data()
 		if err != nil {
 			log.Warn("failed to retrieve L3 monitoring data: %v", err)
@@ -581,7 +582,7 @@ func (r *resctrlGroup) relPath(elem ...string) string {
 }
 
 func (r *resctrlGroup) path(elem ...string) string {
-	return filepath.Join(rdt.info.resctrlPath, r.relPath(elem...))
+	return filepath.Join(info.resctrlPath, r.relPath(elem...))
 }
 
 func newMonGroup(prefix string, name string, parent *ctrlGroup, annotations map[string]string) (*monGroup, error) {

--- a/pkg/rdt/rdt.go
+++ b/pkg/rdt/rdt.go
@@ -139,7 +139,7 @@ func SetLogger(l Logger) {
 }
 
 // Initialize discovers RDT support and initializes the  rdtControl singleton interface
-func Initialize(resctrlGroupPrefix string, conf *Config) error {
+func Initialize(resctrlGroupPrefix string) error {
 	var err error
 
 	info = nil
@@ -151,14 +151,7 @@ func Initialize(resctrlGroupPrefix string, conf *Config) error {
 		return err
 	}
 
-	r := &control{Logger: log, resctrlGroupPrefix: resctrlGroupPrefix}
-
-	// Configure resctrl
-	if err = r.setConfig(conf); err != nil {
-		return rdtError("configuration failed: %v", err)
-	}
-
-	rdt = r
+	rdt = &control{Logger: log, resctrlGroupPrefix: resctrlGroupPrefix}
 
 	return nil
 }

--- a/pkg/rdt/rdt_test.go
+++ b/pkg/rdt/rdt_test.go
@@ -181,8 +181,11 @@ func TestRdt(t *testing.T) {
 	defer mockFs.delete()
 
 	conf := parseTestConfig(t, rdtTestConfig)
-	if err := Initialize(mockGroupPrefix, conf); err != nil {
+	if err := Initialize(mockGroupPrefix); err != nil {
 		t.Fatalf("rdt initialization failed: %v", err)
+	}
+	if err := SetConfig(conf); err != nil {
+		t.Fatalf("rdt configuration failed: %v", err)
 	}
 
 	// Check that the path() and relPath() methods work correctly

--- a/pkg/rdt/rdt_test.go
+++ b/pkg/rdt/rdt_test.go
@@ -151,8 +151,7 @@ func TestRdt(t *testing.T) {
 	//
 	// 1. test uninitialized interface
 	//
-	l := NewLoggerWrapper(stdlog.New(os.Stderr, "[ rdt-test ] ", 0))
-	SetLogger(l)
+	SetLogger(NewLoggerWrapper(stdlog.New(os.Stderr, "[ rdt-test-1 ] ", 0)))
 
 	if err := SetConfig(&Config{}); err == nil {
 		t.Errorf("setting config on uninitialized rdt succeeded unexpectedly")
@@ -186,6 +185,12 @@ func TestRdt(t *testing.T) {
 	}
 	if err := SetConfig(conf); err != nil {
 		t.Fatalf("rdt configuration failed: %v", err)
+	}
+
+	// Check that SetLogger() takes effect in the control interface, too
+	SetLogger(NewLoggerWrapper(stdlog.New(os.Stderr, "[ rdt-test-2 ] ", 0)))
+	if p := rdt.Logger.(*logger).Prefix(); p != "[ rdt-test-2 ] " {
+		t.Errorf("unexpected logger prefix %q", p)
 	}
 
 	// Check that the path() and relPath() methods work correctly

--- a/pkg/rdt/rdt_test.go
+++ b/pkg/rdt/rdt_test.go
@@ -154,15 +154,21 @@ func TestRdt(t *testing.T) {
 	l := NewLoggerWrapper(stdlog.New(os.Stderr, "[ rdt-test ] ", 0))
 	SetLogger(l)
 
-	rdt = &control{Logger: log}
+	if err := SetConfig(&Config{}); err == nil {
+		t.Errorf("setting config on uninitialized rdt succeeded unexpectedly")
 
-	classes := GetClasses()
-	if len(classes) != 0 {
+	}
+	if classes := GetClasses(); len(classes) != 0 {
 		t.Errorf("uninitialized rdt contains classes %s", classes)
 	}
-
 	if _, ok := GetClass(""); ok {
 		t.Errorf("expected to not get a class with empty name")
+	}
+	if MonSupported() {
+		t.Errorf("unitialized rdt claims monitoring to be supported")
+	}
+	if features := GetMonFeatures(); len(features) != 0 {
+		t.Errorf("uninitialized rdt returned monitoring features %s", features)
 	}
 
 	//
@@ -206,7 +212,7 @@ func TestRdt(t *testing.T) {
 	}
 
 	// Verify GetClasses
-	classes = GetClasses()
+	classes := GetClasses()
 	names := make([]string, len(classes))
 	for i, cls := range classes {
 		names[i] = cls.Name()


### PR DESCRIPTION
- separate info from the control interface:
  Better and cleaner to have info as a separate singleton object as other parts (like config and ctrl group management classes) also depend on it.
- don't try to use uninitialized rdt interface
- disable rdt interface if initialization fails
- separate initialization from configuration:
  Now SetConfig() must be separately called after Initialize().
